### PR TITLE
security: remove secret-like vars from wrangler.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+wrangler.toml.bak.*

--- a/SECURITY-NOTES.md
+++ b/SECURITY-NOTES.md
@@ -1,0 +1,9 @@
+# Security notes
+
+## Wrangler / Cloudflare config
+
+- Do not commit secrets (passwords, tokens) in `wrangler.toml`.
+- Store secrets using Cloudflare secrets / environment variables in the Cloudflare dashboard or via `wrangler secret put` (for Workers).
+- For Pages environment variables, set them in the Pages project settings (not in git).
+
+If you see values like `ADMIN_PASSWORD` in repo history, rotate them.

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,4 +7,3 @@ binding = "PROPERTIES_KV"
 id = "cc6c70dc4d554b9a83d858bff328bbc6"
 
 [vars]
-ADMIN_PASSWORD = "PropMaz2026!"


### PR DESCRIPTION
Fixes #1\n\n- Removes ADMIN_PASSWORD from wrangler.toml (do not store secrets in git)\n- Adds SECURITY-NOTES.md with guidance to store Pages/Workers secrets in Cloudflare settings or wrangler secrets\n\nNOTE: rotate any leaked credential values if they were real secrets.